### PR TITLE
Added custom_regexp validation rule

### DIFF
--- a/php/JFormComponentSingleLineText.php
+++ b/php/JFormComponentSingleLineText.php
@@ -140,6 +140,11 @@ class JFormComponentSingleLineText extends JFormComponent {
         return preg_match('/^[ABCEGHJKLMNPRSTVXY][0-9][A-Z] [0-9][A-Z][0-9]$/', $options['value']) || $options['value'] == '' ? 'success' : $messageArray;
     }
     
+    public function custom_regexp() {
+        $messageArray = array($options['custom_regexp']['message']);
+        return preg_match ($options['custom_regexp']['regexp'], $options['value']) ? 'success' : $messageArray;
+    }
+    
     public function date($options) {
         $messageArray = array('Must be a date in the mm/dd/yyyy format.');
         return preg_match('/^(0?[1-9]|1[012])[\- \/.](0?[1-9]|[12][0-9]|3[01])[\- \/.](19|20)[0-9]{2}$/', $options['value']) || $options['value'] == '' ? 'success' : $messageArray;

--- a/php/JFormComponentSingleLineText.php
+++ b/php/JFormComponentSingleLineText.php
@@ -141,7 +141,7 @@ class JFormComponentSingleLineText extends JFormComponent {
     }
     
     public function custom_regexp() {
-        $messageArray = array($options['custom_regexp']['message']);
+        $messageArray = array($options['custom_regexp']['custom_message']);
         return preg_match ($options['custom_regexp']['regexp'], $options['value']) ? 'success' : $messageArray;
     }
     

--- a/scripts/JFormComponentSingleLineText.js
+++ b/scripts/JFormComponentSingleLineText.js
@@ -37,6 +37,12 @@ JFormComponentSingleLineText = JFormComponent.extend({
                 var errorMessageArray = ['Must be a valid Canadian postal code.'];
                 return options.value == '' || options.value.match(/^[ABCEGHJKLMNPRSTVXY][0-9][A-Z] [0-9][A-Z][0-9]$/)  ? 'success' : errorMessageArray;
             },
+            'custom_regexp': function(options) {
+                var errorMessageArray = [options.custom_regexp.custom_message];
+                var sm = options.custom_regexp.regexp.substring(1,sm.length-1);						
+                var regular_expression = RegExp(sm);
+                return options.value.match(regular_expression) ? 'success' : errorMessageArray;
+            },
             'date': function(options) {
                 var errorMessageArray = ['Must be a date in the mm/dd/yyyy format.'];
                 return options.value == '' || options.value.match(/^(0?[1-9]|1[012])[\- \/.](0?[1-9]|[12][0-9]|3[01])[\- \/.](19|20)[0-9]{2}$/)  ? 'success' : errorMessageArray;


### PR DESCRIPTION
I've added the custom_regexp validation rule to JFormComponentSingleLineText , in order to make jformer able to work with many languages and different requirements, I've added the "custom_message" parameter to my validation rule, but I'm interested into do this work with other validation rules. (I'm spanish and I need something more flexible than jformer is today).
