### PR TITLE
Fix server-side validation option error display

### DIFF
--- a/scripts/JFormComponentSingleLineText.js
+++ b/scripts/JFormComponentSingleLineText.js
@@ -231,7 +231,10 @@ JFormComponentSingleLineText = JFormComponent.extend({
                     async: false,
                     success: function(json) {
                         if(json.status != 'success') {
-                            errorMessageArray = json.response;
+                            if($.isArray(json.response))
+                                errorMessageArray = json.response;
+                            else
+                                errorMessageArray = [json.response];
                         }
 
                         options.component.removeClass('jFormComponentServerSideCheck');


### PR DESCRIPTION
When using the 'serverSide' validation option the response value is
converted to an array if it is not one already when setting the error
message array.

Requires jQuery >= 1.3
