### PR TITLE
Email validation option accepts emails with dashes

### DIFF
--- a/scripts/JFormComponentSingleLineText.js
+++ b/scripts/JFormComponentSingleLineText.js
@@ -82,7 +82,7 @@ JFormComponentSingleLineText = JFormComponent.extend({
             },
             'email': function(options) {
                 var errorMessageArray = ['Must be a valid e-mail address.'];
-                return options.value == '' || options.value.match(/^[A-Z0-9._%-\+]+@(?:[A-Z0-9\-]+\.)+[A-Z]{2,4}$/i)  ? 'success' : errorMessageArray;
+                return options.value == '' || options.value.match(/^[A-Z0-9._%\-\+]+@(?:[A-Z0-9\-]+\.)+[A-Z]{2,4}$/i)  ? 'success' : errorMessageArray;
             },
             'integer': function(options) {
                 var errorMessageArray = ['Must be a whole number.'];


### PR DESCRIPTION
Hyphen was not escaped in the local part's character class.

This still leaves the regex short of what is recommended by RFC 3696.
The correct solution may be to use the "email" value for the type
attribute on component's associated input element, introduced in HTML5.
