### PR TITLE
Form 'action' fix for non-canonical document roots

### DIFF
--- a/php/JFormer.php
+++ b/php/JFormer.php
@@ -77,7 +77,7 @@ class JFormer {
         // Set the action dynamically
         $callingFile = debug_backtrace();
         $callingFile = str_replace("\\", "/", $callingFile[0]['file']);
-        $this->action = str_replace($_SERVER['DOCUMENT_ROOT'], '', $callingFile);
+        $this->action = str_replace(realpath($_SERVER['DOCUMENT_ROOT']), '', realpath($callingFile));
 
         // Use the options array to update the form variables
         if (is_array($optionArray)) {


### PR DESCRIPTION
The 'action' attribute on jFormer forms is correctly determined when
the website's document root is a non-canonical path, e.g. a symlink.

NOTE: This will not fix path problems that people might encounter if the form-processing PHP file itself uses a non-canonical path that is not a sub-path of the document root. In that case it would probably be better to pass $_SERVER['PHP_SELF'] as the 'action' option when constructing the JFormer object.
